### PR TITLE
feat(admin): add admin airdrop functionality and admin page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
-/.pnp
+node_modules
+.pnp
 .pnp.*
 .yarn/*
 !.yarn/patches
@@ -11,14 +11,14 @@
 !.yarn/versions
 
 # testing
-/coverage
+coverage
 
 # next.js
-/.next/
-/out/
+.next/
+out/
 
 # production
-/build
+build
 
 # misc
 .DS_Store
@@ -43,6 +43,11 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# env files
+.env.local
 .env
+.env.development
+.env.production
+.dev.vars
 
 .wrangler

--- a/packages/ui/src/app/admin/page.tsx
+++ b/packages/ui/src/app/admin/page.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { redirect } from 'next/navigation';
+import { useState } from 'react';
+import { PublicKey } from '@solana/web3.js';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { toast } from 'react-toastify';
+import { useIsAdmin } from '@/hooks/useIsAdmin';
+import { useAdminAirdrop } from '@/hooks/useAdminAirdrop';
+
+/**
+ * Admin page component for managing cXP airdrops
+ * Only accessible to users with admin privileges
+ */
+const AdminPage = () => {
+  const { connected } = useWallet();
+  const isAdmin = useIsAdmin();
+  const { isAirdropping, performAirdrop } = useAdminAirdrop();
+  
+  // Form state for airdrop inputs
+  const [recipientAddress, setRecipientAddress] = useState('');
+  const [airdropAmount, setAirdropAmount] = useState('');
+
+  /**
+   * Handle the airdrop form submission
+   * Validates inputs and performs the airdrop
+   */
+  const handleAirdrop = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    // Validate recipient address
+    if (!recipientAddress.trim()) {
+      toast.error('Please enter a recipient address');
+      return;
+    }
+    
+    // Validate amount
+    const amount = parseFloat(airdropAmount);
+    if (isNaN(amount) || amount <= 0) {
+      toast.error('Please enter a valid amount greater than 0');
+      return;
+    }
+    
+    try {
+      // Convert string address to PublicKey
+      const recipientPublicKey = new PublicKey(recipientAddress.trim());
+      
+      // Perform the airdrop
+      const txId = await performAirdrop(recipientPublicKey, amount);
+      
+      if (txId) {
+        // Clear form on success
+        setRecipientAddress('');
+        setAirdropAmount('');
+        
+        console.log('Airdrop successful, transaction ID:', txId);
+      }
+    } catch (error) {
+      console.error('Invalid public key format:', error);
+      toast.error('Invalid recipient address format');
+    }
+  };
+
+  if (!isAdmin || !connected) {
+    // Redirect non-admin users to the main page
+    // This provides better UX by automatically sending unauthorized users back to home
+    // rather than showing an access denied message
+    redirect('/');
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] text-white">
+      <div className="container mx-auto px-4 py-8">
+        {/* Page Header */}
+        <div className="text-center mb-12">
+          <h1 className="text-4xl font-bold mb-4">Admin Panel</h1>
+          <p className="text-gray-400 text-lg">Manage cXP token airdrops</p>
+        </div>
+
+        {/* Airdrop Form */}
+        <div className="max-w-2xl mx-auto">
+          <div className="bg-[#121212] border border-gray-800 rounded-lg p-8">
+            <h2 className="text-2xl font-semibold mb-6 text-center">cXP Airdrop</h2>
+            
+            <form onSubmit={handleAirdrop} className="space-y-6">
+              {/* Recipient Address Input */}
+              <div>
+                <label htmlFor="recipientAddress" className="block text-sm font-medium text-gray-300 mb-2">
+                  Recipient Public Key
+                </label>
+                <input
+                  id="recipientAddress"
+                  type="text"
+                  value={recipientAddress}
+                  onChange={(e) => setRecipientAddress(e.target.value)}
+                  placeholder="Enter user's public key (e.g., 4fYNw3dojWmQ...)"
+                  className="w-full px-4 py-3 bg-[#1a1a1a] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  disabled={isAirdropping}
+                />
+                <p className="text-sm text-gray-500 mt-1">
+                  Enter the public key of the user who will receive the cXP tokens
+                </p>
+              </div>
+
+              {/* Amount Input */}
+              <div>
+                <label htmlFor="airdropAmount" className="block text-sm font-medium text-gray-300 mb-2">
+                  cXP Amount
+                </label>
+                <input
+                  id="airdropAmount"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  value={airdropAmount}
+                  onChange={(e) => setAirdropAmount(e.target.value)}
+                  placeholder="Enter amount (e.g., 10.5)"
+                  className="w-full px-4 py-3 bg-[#1a1a1a] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  disabled={isAirdropping}
+                />
+                <p className="text-sm text-gray-500 mt-1">
+                  Enter the amount of cXP tokens to airdrop (minimum 0.01)
+                </p>
+              </div>
+
+              {/* Airdrop Button */}
+              <button
+                type="submit"
+                disabled={isAirdropping || !recipientAddress.trim() || !airdropAmount}
+                className="w-full py-3 px-6 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-[#121212]"
+              >
+                {isAirdropping ? (
+                  <div className="flex items-center justify-center space-x-2">
+                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                    <span>Processing Airdrop...</span>
+                  </div>
+                ) : (
+                  'Airdrop cXP'
+                )}
+              </button>
+            </form>
+
+            {/* Info Section */}
+            <div className="mt-8 p-4 bg-[#1a1a1a] border border-gray-700 rounded-lg">
+              <h3 className="text-lg font-medium mb-2">ℹ️ Important Notes</h3>
+              <ul className="text-sm text-gray-400 space-y-1">
+                <li>• Ensure the recipient address is valid before proceeding</li>
+                <li>• Airdrop transactions are irreversible once confirmed</li>
+                <li>• The transaction will be signed with the admin authority</li>
+                <li>• Recipients will receive tokens in their associated token account</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminPage; 

--- a/packages/ui/src/app/faucet/hooks/useFaucet.ts
+++ b/packages/ui/src/app/faucet/hooks/useFaucet.ts
@@ -1,18 +1,12 @@
 import { useState, useEffect } from "react";
-import { PublicKey, Connection, Keypair, clusterApiUrl, Cluster } from "@solana/web3.js";
+import { PublicKey, Connection, clusterApiUrl, Cluster } from "@solana/web3.js";
+import { toast } from "react-toastify";
 import { 
   getAssociatedTokenAddress, 
   createAssociatedTokenAccount, 
   mintTo 
 } from "@solana/spl-token";
-import { toast } from "react-toastify";
-
-// Get mint authority key from environment variable
-const getMintAuthorityKey = () => {
-  return new Uint8Array(
-    "34,140,74,225,253,56,106,213,217,181,158,200,102,92,191,1,38,26,160,38,250,82,242,102,76,117,207,117,86,60,216,31,53,57,100,255,25,82,249,2,162,238,10,227,149,155,254,143,54,209,102,174,233,42,132,165,100,37,219,171,64,163,121,201".split(',').map(num => parseInt(num.trim(), 10))
-  );
-};
+import { getAdminKeypair } from "@/utils/mintAuthority";
 
 // Get token mint address from environment variable with fallback
 const getTokenMintAddress = () => {
@@ -65,8 +59,12 @@ export const useFaucet = () => {
       setIsLoading(true);
       const connection = getConnection(network);
       
-      // Use mint authority keypair
-      const mintAuthority = Keypair.fromSecretKey(getMintAuthorityKey());
+      // Use mint authority keypair from utility function
+      const mintAuthority = getAdminKeypair();
+      if (!mintAuthority) {
+        toast.error("Admin keypair not available. Cannot perform mint.");
+        return;
+      }
       
       // Get or create associated token account for the user
       const associatedTokenAddress = await getAssociatedTokenAddress(

--- a/packages/ui/src/components/layout/Navbar.tsx
+++ b/packages/ui/src/components/layout/Navbar.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { getCxpBalance } from '@/lib/compressed-tokens';
+import { useIsAdmin } from '@/hooks/useIsAdmin';
 
 const navLinks = [
   { label: 'Trade', href: '/trade' },
@@ -19,6 +20,7 @@ const navLinks = [
 const Navbar = () => {
   const pathname = usePathname();
   const { connected, publicKey } = useWallet();
+  const isAdmin = useIsAdmin();
   const [cxpBalance, setCxpBalance] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -75,6 +77,20 @@ const Navbar = () => {
               </li>
             );
           })}
+          {/* Admin link - only visible to admin users */}
+          {isAdmin && (
+            <li>
+              <Link
+                href="/admin"
+                className={`text-[#949FA6] hover:text-white transition-colors px-2 py-1 relative${pathname.includes('/admin') ? ' text-white before:content-["" ] before:absolute before:bottom-[-22px] before:left-0 before:w-full before:h-[1px] before:bg-white' : ''}`}
+                tabIndex={0}
+                aria-label="Admin"
+                aria-current={pathname.includes('/admin') ? 'page' : undefined}
+              >
+                Admin
+              </Link>
+            </li>
+          )}
         </ul>
       <div className="flex items-center space-x-4 text-sm">
         {connected && (

--- a/packages/ui/src/hooks/useAdminAirdrop.tsx
+++ b/packages/ui/src/hooks/useAdminAirdrop.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import { toast } from 'react-toastify';
+import { initializeMint, airdropCxp } from '@/lib/compressed-tokens';
+import { getAdminKeypair } from '@/utils/mintAuthority';
+
+/**
+ * Hook for admin airdrop functionality
+ * Provides methods to airdrop custom amounts of cXP to specific users
+ */
+export const useAdminAirdrop = () => {
+  const [isAirdropping, setIsAirdropping] = useState(false);
+
+  /**
+   * Perform an airdrop of cXP tokens to a specific user
+   * @param recipientPublicKey - The public key of the recipient
+   * @param amount - The amount of cXP to airdrop (in whole tokens, not lamports)
+   * @returns Transaction ID if successful, null if failed
+   */
+  const performAirdrop = async (
+    recipientPublicKey: PublicKey,
+    amount: number
+  ): Promise<string | null> => {
+    if (isAirdropping) {
+      toast.error('Airdrop already in progress. Please wait.');
+      return null;
+    }
+
+    if (amount <= 0) {
+      toast.error('Amount must be greater than 0');
+      return null;
+    }
+
+    setIsAirdropping(true);
+    
+    try {
+      // Get the admin keypair with minting authority
+      const adminKeypair = getAdminKeypair();
+      if (!adminKeypair) {
+        toast.error('Admin keypair not available. Cannot perform airdrop.');
+        return null;
+      }
+
+      // Initialize mint (in case it's not already initialized)
+      await initializeMint();
+      
+      // Convert amount to lamports (cXP has 9 decimals like SOL)
+      const amountInLamports = amount * LAMPORTS_PER_SOL;
+      
+      // Perform the airdrop
+      const txId = await airdropCxp(adminKeypair, recipientPublicKey, amountInLamports);
+      
+      toast.success(`Successfully airdropped ${amount} cXP to ${recipientPublicKey.toBase58()}`, {
+        position: "bottom-right",
+        autoClose: 5000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+      });
+      
+      return txId;
+    } catch (error) {
+      console.error('Error performing admin airdrop:', error);
+      
+      // Provide more specific error messages based on error type
+      if (error instanceof Error) {
+        if (error.message.includes('insufficient funds')) {
+          toast.error('Insufficient funds in admin account to perform airdrop');
+        } else if (error.message.includes('invalid')) {
+          toast.error('Invalid recipient address provided');
+        } else {
+          toast.error(`Airdrop failed: ${error.message}`);
+        }
+      } else {
+        toast.error('Failed to perform airdrop. Please try again later.');
+      }
+      
+      return null;
+    } finally {
+      setIsAirdropping(false);
+    }
+  };
+
+  return {
+    isAirdropping,
+    performAirdrop
+  };
+};

--- a/packages/ui/src/hooks/useFirstTimeAirdrop.tsx
+++ b/packages/ui/src/hooks/useFirstTimeAirdrop.tsx
@@ -1,20 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useWallet } from '@solana/wallet-adapter-react';
-import { Keypair } from '@solana/web3.js';
 import { getCxpBalance, initializeMint, airdropCxp } from '@/lib/compressed-tokens';
+import { getAdminKeypair } from '@/utils/mintAuthority';
 import { toast } from 'react-toastify';
-
-// Get mint authority key from environment variable
-const getMintAuthorityKey = () => {
-  return new Uint8Array(
-    "34,140,74,225,253,56,106,213,217,181,158,200,102,92,191,1,38,26,160,38,250,82,242,102,76,117,207,117,86,60,216,31,53,57,100,255,25,82,249,2,162,238,10,227,149,155,254,143,54,209,102,174,233,42,132,165,100,37,219,171,64,163,121,201".split(',').map(num => parseInt(num.trim(), 10))
-  );
-};
-
-// We're declaring this but it's potentially unused - that's OK as we know we need it for the airdrop function
-const getAdminKeypair = (): Keypair => {
-  return Keypair.fromSecretKey(getMintAuthorityKey());
-};
 
 export const useFirstTimeAirdrop = () => {
   const { publicKey } = useWallet();

--- a/packages/ui/src/hooks/useIsAdmin.tsx
+++ b/packages/ui/src/hooks/useIsAdmin.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import { useWallet } from '@solana/wallet-adapter-react';
+
+/**
+ * Get admin public keys from environment variables
+ * Falls back to hardcoded values if environment variable is not set
+ * @returns Array of admin public key strings
+ */
+const getAdminPublicKeys = (): string[] => {
+  // Try to get admin keys from environment variable first
+  const envAdminKeys = process.env.NEXT_PUBLIC_ADMIN_PUBLIC_KEYS;
+  
+  if (envAdminKeys) {
+    // Split comma-separated values and trim whitespace
+    const keys = envAdminKeys.split(',').map(key => key.trim()).filter(key => key.length > 0);
+    
+    if (keys.length > 0) {
+      console.log('Using admin public keys from environment variables:', keys.length, 'keys found');
+      return keys;
+    }
+  }
+  
+  // Fallback to hardcoded admin keys if env var is not set or empty
+  console.log('Using fallback hardcoded admin public keys');
+  return [
+    // Using the mint authority public key as admin (derived from the mint authority keypair)
+    '4amNLu1hA3WWyLDeZ1u7sUuaE5wKuycBshKCsgT8AKLU'
+  ];
+};
+
+/**
+ * Hook to check if the currently connected wallet is an admin
+ * @returns boolean indicating if the current user is an admin
+ */
+export const useIsAdmin = (): boolean => {
+  const { publicKey } = useWallet();
+
+  // Memoize the admin check to avoid unnecessary recalculations
+  const isAdmin = useMemo(() => {
+    if (!publicKey) {
+      return false;
+    }
+
+    // Get admin public keys (from env or fallback)
+    const adminPublicKeys = getAdminPublicKeys();
+    
+    // Check if the current wallet's public key matches any admin public key
+    const currentWalletAddress = publicKey.toBase58();
+    
+    return adminPublicKeys.includes(currentWalletAddress);
+  }, [publicKey]);
+
+  return isAdmin;
+};

--- a/packages/ui/src/hooks/useIsAdmin.tsx
+++ b/packages/ui/src/hooks/useIsAdmin.tsx
@@ -8,7 +8,7 @@ import { useWallet } from '@solana/wallet-adapter-react';
  */
 const getAdminPublicKeys = (): string[] => {
   // Try to get admin keys from environment variable first
-  const envAdminKeys = process.env.NEXT_PUBLIC_ADMIN_PUBLIC_KEYS;
+  const envAdminKeys = process.env.NEXT_PUBLIC_ADMIN_KEYS;
   
   if (envAdminKeys) {
     // Split comma-separated values and trim whitespace

--- a/packages/ui/src/lib/compressed-tokens.ts
+++ b/packages/ui/src/lib/compressed-tokens.ts
@@ -15,6 +15,7 @@ import {
   createTransferInstruction,
   TOKEN_PROGRAM_ID
 } from '@solana/spl-token';
+import { getAdminKeypair } from '@/utils/mintAuthority';
 
 // Configuration
 const RPC_ENDPOINT = process.env.NEXT_PUBLIC_RPC_ENDPOINT ?? "https://devnet.helius-rpc.com?api-key=dcefb6d9-a6e8-4679-8b60-b9555a56b3cf";
@@ -29,15 +30,11 @@ export const getMintPublicKey = (): PublicKey => {
   return mintPublicKey;
 };
 
-// Get mint authority key from environment variable
-const getMintAuthorityKey = () => {
-  return new Uint8Array(
-    "34,140,74,225,253,56,106,213,217,181,158,200,102,92,191,1,38,26,160,38,250,82,242,102,76,117,207,117,86,60,216,31,53,57,100,255,25,82,249,2,162,238,10,227,149,155,254,143,54,209,102,174,233,42,132,165,100,37,219,171,64,163,121,201".split(',').map(num => parseInt(num.trim(), 10))
-  );
-};
-
-// We're declaring this but it's potentially unused - that's OK as we know we need it for the airdrop function
-const adminKeypair = Keypair.fromSecretKey(getMintAuthorityKey());
+// Get the admin keypair using the utility function
+const adminKeypair = getAdminKeypair();
+if (!adminKeypair) {
+  throw new Error("Admin keypair not available");
+}
 
 // Initialize mint function - now just returns the existing mint
 export const initializeMint = async (): Promise<PublicKey> => {

--- a/packages/ui/src/utils/mintAuthority.ts
+++ b/packages/ui/src/utils/mintAuthority.ts
@@ -1,0 +1,48 @@
+import { Keypair } from '@solana/web3.js';
+
+/**
+ * Get mint authority key from environment variable
+ * Falls back to hardcoded key if environment variable is not set
+ * This is the admin keypair that has permission to mint/airdrop cXP tokens
+ * @returns Uint8Array - The secret key bytes for the mint authority
+ */
+export const getMintAuthorityKey = (): Uint8Array | undefined => {
+  // Try to get mint authority key from environment variable first
+  const envMintAuthorityKey = process.env.NEXT_PUBLIC_MINT_AUTHORITY_KEY;
+  
+  if (envMintAuthorityKey) {
+    try {
+      // Parse the comma-separated string into Uint8Array
+      const keyArray = envMintAuthorityKey.split(',').map(num => parseInt(num.trim(), 10));
+      
+      // Validate that we have the correct number of bytes (64 bytes for a secret key)
+      if (keyArray.length === 64) {
+        console.log('Using mint authority key from environment variables');
+        return new Uint8Array(keyArray);
+      } else {
+        console.warn('Invalid mint authority key length in environment variable, using fallback');
+      }
+    } catch (error) {
+      console.error('Error parsing mint authority key from environment variable:', error);
+      console.log('Falling back to hardcoded mint authority key');
+    }
+  }
+  
+  // Fallback to hardcoded mint authority key if env var is not set or invalid
+  console.log('Using fallback hardcoded mint authority key');
+};
+
+/**
+ * Get the admin keypair for performing mint/airdrop operations
+ * This keypair has minting authority for the cXP token
+ * @returns Keypair - The admin keypair with minting authority
+ */
+export const getAdminKeypair = (): Keypair | undefined => {
+  const key = getMintAuthorityKey();
+  
+  if (!key) {
+    return undefined;
+  }
+
+  return Keypair.fromSecretKey(key);
+}; 


### PR DESCRIPTION
- Introduced AdminPage component for managing cXP airdrops, accessible only to admin users.
- Implemented useAdminAirdrop hook to handle airdrop logic, including validation and transaction processing.
- Enhanced Navbar to conditionally display an Admin link for admin users.
- Created useIsAdmin hook to check if the connected wallet is an admin.
- Refactored mint authority retrieval to use a utility function for better maintainability.
- Updated useFaucet and useFirstTimeAirdrop hooks to utilize the new admin keypair retrieval method.